### PR TITLE
DOC/BLD: add custom sphinx autodoc AccessorAttributeDocumenter

### DIFF
--- a/doc/_templates/autosummary/accessor_attribute.rst
+++ b/doc/_templates/autosummary/accessor_attribute.rst
@@ -1,0 +1,6 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module.split('.')[0] }}
+
+.. autoaccessorattribute:: {{ [module.split('.')[1], objname]|join('.') }}

--- a/doc/_templates/autosummary/accessor_method.rst
+++ b/doc/_templates/autosummary/accessor_method.rst
@@ -1,0 +1,6 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module.split('.')[0] }}
+
+.. autoaccessormethod:: {{ [module.split('.')[1], objname]|join('.') }}

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -455,6 +455,7 @@ These can be accessed like ``Series.dt.<property>``.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_attribute.rst
 
    Series.dt.date
    Series.dt.time
@@ -483,6 +484,7 @@ These can be accessed like ``Series.dt.<property>``.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_method.rst
 
    Series.dt.to_period
    Series.dt.to_pydatetime
@@ -493,6 +495,7 @@ These can be accessed like ``Series.dt.<property>``.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_attribute.rst
 
    Series.dt.days
    Series.dt.seconds
@@ -504,6 +507,7 @@ These can be accessed like ``Series.dt.<property>``.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_method.rst
 
    Series.dt.to_pytimedelta
 
@@ -515,6 +519,7 @@ strings and apply several methods to it. These can be acccessed like
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_method.rst
 
    Series.str.cat
    Series.str.center


### PR DESCRIPTION
Accessor attributes/methods like Series.str.match or Series.dt.hour
cannot be processed by the default autosummary/autodoc machinery.
So added:

- autosummary template
- autodoc custom Documenter that fixes the recognition of the
  correct module and object

Related to GH9322 (reimplement Series delegates/accessors using descriptors)
to be able to document the accessors as eg pandas.Series.str.match and not
pandas.core.strings.StringMethods.match